### PR TITLE
[ADD] visiting as guest button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ teedy-importer-win.exe
 docs/*
 !docs/.gitkeep
 
+# Dev persistence (H2 DB, Lucene index, uploaded files when using mvn jetty:run)
+data/
+
 #macos
 .DS_Store

--- a/docs-core/src/dev/resources/db/update/dbupdate-000-1.sql
+++ b/docs-core/src/dev/resources/db/update/dbupdate-000-1.sql
@@ -1,1 +1,2 @@
-update T_CONFIG set CFG_VALUE_C = 'RAM' where CFG_ID_C = 'LUCENE_DIRECTORY_STORAGE';
+-- Use FILE so Lucene index persists across server restarts (dev persistence)
+update T_CONFIG set CFG_VALUE_C = 'FILE' where CFG_ID_C = 'LUCENE_DIRECTORY_STORAGE';

--- a/docs-web/pom.xml
+++ b/docs-web/pom.xml
@@ -176,16 +176,30 @@
         </resources>
 
         <plugins>
+          <!-- In dev, expose frontend at webapp root so / serves index.html -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+            <configuration>
+              <webResources>
+                <resource>
+                  <directory>${project.basedir}/src/main/webapp/src</directory>
+                  <targetPath>.</targetPath>
+                </resource>
+              </webResources>
+            </configuration>
+          </plugin>
           <plugin>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-maven-plugin</artifactId>
             <configuration>
               <systemProperties>
                 <application.mode>dev</application.mode>
-                <docs.home>../data/docs</docs.home>
+                <!-- Absolute path so DB and Lucene storage persist across restarts -->
+                <docs.home>${project.basedir}/../data/docs</docs.home>
               </systemProperties>
               <webApp>
-                <contextPath>/docs-web</contextPath>
+                <contextPath>/</contextPath>
                 <overrideDescriptor>${project.basedir}/src/dev/main/webapp/web-override.xml</overrideDescriptor>
               </webApp>
             </configuration>

--- a/docs-web/src/dev/main/webapp/web-override.xml
+++ b/docs-web/src/dev/main/webapp/web-override.xml
@@ -5,6 +5,9 @@
          xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
          version="5.0"
          metadata-complete="true">
+  <welcome-file-list>
+    <welcome-file>index.html</welcome-file>
+  </welcome-file-list>
   <!-- Override init parameter to avoid nasty file locking issue on windows. -->
   <servlet>
     <servlet-name>default</servlet-name>

--- a/docs-web/src/dev/resources/hibernate.properties
+++ b/docs-web/src/dev/resources/hibernate.properties
@@ -1,5 +1,6 @@
 hibernate.connection.driver_class=org.h2.Driver
-hibernate.connection.url=jdbc:h2:mem:docs
+# File-based H2 so data persists across server restarts (docs.home is set by Jetty in dev)
+hibernate.connection.url=jdbc:h2:file:${docs.home}/db/docs;CACHE_SIZE=65536;LOCK_TIMEOUT=10000
 hibernate.connection.username=sa
 hibernate.connection.password=
 hibernate.hbm2ddl.auto=

--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -74,9 +74,9 @@
             </div>
           </div>
 
-          <p class="text-center" ng-if="app.guest_login">&nbsp;</p>
+          <p class="text-center">&nbsp;</p>
 
-          <button type="submit" class="btn btn-default btn-block" ng-if="app.guest_login" ng-click="loginAsGuest()">
+          <button type="submit" class="btn btn-default btn-block" ng-click="loginAsGuest()">
             <span class="fas fa-user"></span> {{ 'login.login_as_guest' | translate }}
           </button>
         </form>


### PR DESCRIPTION
## Summary by Sourcery

Enable guest login by default and improve the development webapp’s root configuration and data persistence.

New Features:
- Always display the guest login button on the login page.

Enhancements:
- Serve the docs web application at the root context with index.html as the welcome file in development.
- Expose the frontend resources at the webapp root during development via the WAR plugin configuration.
- Use an absolute docs.home path and switch the dev H2 database to file-based storage so data and indexes persist across server restarts.